### PR TITLE
Provide status callbacks.

### DIFF
--- a/Service/Worker/AbstractWorker.php
+++ b/Service/Worker/AbstractWorker.php
@@ -10,6 +10,9 @@ use TriTran\SqsQueueBundle\Service\Message;
  */
 abstract class AbstractWorker
 {
+    /** @var string  Worker error message after processing. */
+    private $error = null;
+
     /**
      * @param Message $message
      *
@@ -27,9 +30,13 @@ abstract class AbstractWorker
         try {
             $result = $this->execute($message);
         } catch (\Exception $e) {
-            return false;
+            $result = false;
+            $this->error = $e->getMessage();
         }
         $this->postExecute($message);
+
+        // Let worker does something on success or failure
+        $result === true ? $this->onSucceeded() : $this->onFailed();
 
         return $result;
     }
@@ -43,6 +50,8 @@ abstract class AbstractWorker
     }
 
     /**
+     * Do something via post execution. It is better to proceed with task related to message.
+     *
      * @param Message $message
      */
     protected function postExecute(Message $message)
@@ -56,4 +65,39 @@ abstract class AbstractWorker
      * @return boolean
      */
     abstract protected function execute(Message $message);
+
+    /**
+     * Event fired when worker has processed message successfully.
+     *
+     * @return void
+     */
+    abstract protected function onSucceeded();
+
+    /**
+     * Event fired when worker has failed to process message.
+     *
+     * @return void
+     */
+    abstract protected function onFailed();
+
+    /**
+     * Check if worker has error after processing.
+     * By default, error is set to <code>null</code>.
+     *
+     * @return bool
+     */
+    public function hasError()
+    {
+        return $this->error !== null;
+    }
+
+    /**
+     * Get worker error message.
+     *
+     * @return string
+     */
+    public function error()
+    {
+        return $this->error;
+    }
 }

--- a/Service/Worker/AbstractWorker.php
+++ b/Service/Worker/AbstractWorker.php
@@ -71,14 +71,20 @@ abstract class AbstractWorker
      *
      * @return void
      */
-    abstract protected function onSucceeded();
+    protected function onSucceeded()
+    {
+        // Do something here
+    }
 
     /**
      * Event fired when worker has failed to process message.
      *
      * @return void
      */
-    abstract protected function onFailed();
+    protected function onFailed()
+    {
+        // Do something here
+    }
 
     /**
      * Check if worker has error after processing.

--- a/Tests/Unit/Service/Worker/AbstractWorkerTest.php
+++ b/Tests/Unit/Service/Worker/AbstractWorkerTest.php
@@ -19,6 +19,7 @@ class AbstractWorkerTest extends TestCase
     {
         /** @var \PHPUnit_Framework_MockObject_MockObject|AbstractWorker $client */
         $worker = $this->getMockBuilder(AbstractWorker::class)
+            ->setMethods(['preExecute', 'postExecute', 'onSucceeded', 'onFailed'])
             ->getMockForAbstractClass();
 
         return $worker;
@@ -51,6 +52,10 @@ class AbstractWorkerTest extends TestCase
             ->method('execute')
             ->with($message)
             ->willReturn(true);
+        $worker->expects($this->once())->method(('preExecute'))->with($message);
+        $worker->expects($this->once())->method(('postExecute'))->with($message);
+        $worker->expects($this->once())->method('onSucceeded');
+        $worker->expects($this->never())->method('onFailed');
 
         $result = $worker->process($message);
 
@@ -71,6 +76,10 @@ class AbstractWorkerTest extends TestCase
             ->method('execute')
             ->with($message)
             ->willThrowException(new \Exception());
+        $worker->expects($this->once())->method(('preExecute'))->with($message);
+        $worker->expects($this->once())->method(('postExecute'))->with($message);
+        $worker->expects($this->once())->method('onFailed');
+        $worker->expects($this->never())->method('onSucceeded');
 
         $result = $worker->process($message);
 

--- a/Tests/Unit/Service/Worker/AbstractWorkerTest.php
+++ b/Tests/Unit/Service/Worker/AbstractWorkerTest.php
@@ -51,10 +51,6 @@ class AbstractWorkerTest extends TestCase
             ->method('execute')
             ->with($message)
             ->willReturn(true);
-        $worker->expects($this->once())
-            ->method('onSucceeded');
-        $worker->expects($this->never())
-            ->method('onFailed');
 
         $result = $worker->process($message);
 
@@ -75,10 +71,6 @@ class AbstractWorkerTest extends TestCase
             ->method('execute')
             ->with($message)
             ->willThrowException(new \Exception());
-        $worker->expects($this->once())
-            ->method('onFailed');
-        $worker->expects($this->never())
-            ->method('onSucceeded');
 
         $result = $worker->process($message);
 

--- a/Tests/Unit/Service/Worker/AbstractWorkerTest.php
+++ b/Tests/Unit/Service/Worker/AbstractWorkerTest.php
@@ -51,9 +51,16 @@ class AbstractWorkerTest extends TestCase
             ->method('execute')
             ->with($message)
             ->willReturn(true);
+        $worker->expects($this->once())
+            ->method('onSucceeded');
+        $worker->expects($this->never())
+            ->method('onFailed');
 
         $result = $worker->process($message);
+
         $this->assertTrue($result);
+        $this->assertFalse($worker->hasError());
+        $this->assertNull($worker->error());
     }
 
     /**
@@ -68,8 +75,15 @@ class AbstractWorkerTest extends TestCase
             ->method('execute')
             ->with($message)
             ->willThrowException(new \Exception());
+        $worker->expects($this->once())
+            ->method('onFailed');
+        $worker->expects($this->never())
+            ->method('onSucceeded');
 
         $result = $worker->process($message);
+
         $this->assertFalse($result);
+        $this->assertTrue($worker->hasError());
+        $this->assertNotNull($worker->error());
     }
 }

--- a/Tests/app/Worker/BasicWorker.php
+++ b/Tests/app/Worker/BasicWorker.php
@@ -16,4 +16,20 @@ class BasicWorker extends AbstractWorker
     {
         return true;
     }
+
+    /**
+     * Handle worker on success.
+     */
+    protected function onSucceeded()
+    {
+
+    }
+
+    /**
+     * Handle worker on failure.
+     */
+    protected function onFailed()
+    {
+
+    }
 }

--- a/Tests/app/Worker/BasicWorker.php
+++ b/Tests/app/Worker/BasicWorker.php
@@ -16,20 +16,4 @@ class BasicWorker extends AbstractWorker
     {
         return true;
     }
-
-    /**
-     * Handle worker on success.
-     */
-    protected function onSucceeded()
-    {
-
-    }
-
-    /**
-     * Handle worker on failure.
-     */
-    protected function onFailed()
-    {
-
-    }
 }


### PR DESCRIPTION
This includes following updates:

- Callbacks for `AbstractWorker` on success (`::onSucceeded()`) and on failure (`::onFailed()`).
- Query for error if there is, so the implemented workers, *inherited from `AbstractWorker`*, can catch error exception to handle.